### PR TITLE
style: reformat to be PEP8 compliant

### DIFF
--- a/cluster_posts.py
+++ b/cluster_posts.py
@@ -1,15 +1,16 @@
 import os
 import json
 import argparse
+import time
+import numpy as np
+from utils import preprocess, load_post
+
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.cluster import KMeans
 from nltk.tokenize import word_tokenize
 from nltk.stem.snowball import FrenchStemmer
 from sklearn.cluster import DBSCAN
-import time
-import numpy as np
 
-from utils import preprocess, load_post
 
 def cluster_posts(posts, stem=False, eps=0.5, min_samples=1):
     texts = [p["content"] for p in posts]
@@ -18,14 +19,13 @@ def cluster_posts(posts, stem=False, eps=0.5, min_samples=1):
     X = vectorizer.fit_transform(texts)
 
     # Clustering DBSCAN en utilisant la similarité cosinus
-    model = DBSCAN(eps=eps, min_samples=min_samples, metric='cosine')
+    model = DBSCAN(eps=eps, min_samples=min_samples, metric="cosine")
     labels = model.fit_predict(X)
 
     # On compte le nombre de clusters (uniquement ceux qui contienne au moins deux elt)
     u, c = np.unique(labels, return_counts=True)
-    n_clusters = np.sum(c>1)
+    n_clusters = np.sum(c > 1)
     print(f"Nombre de clusters détectés : {n_clusters}")
-
 
     clusters = {}
     for idx, label in enumerate(labels):
@@ -35,10 +35,18 @@ def cluster_posts(posts, stem=False, eps=0.5, min_samples=1):
 
     return clusters
 
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--folder", default="data", help="Dossier contenant les fichiers JSON")
-    parser.add_argument("--sim", type=float, default=0.5, help="similarité minimal pour l'ajout d'un post dans un cluster. Compris entre 0 et 1")
+    parser.add_argument(
+        "--folder", default="data", help="Dossier contenant les fichiers JSON"
+    )
+    parser.add_argument(
+        "--sim",
+        type=float,
+        default=0.5,
+        help="similarité minimal pour l'ajout d'un post dans un cluster. Compris entre 0 et 1",
+    )
     parser.add_argument("--stem", action="store_true")
     args = parser.parse_args()
 
@@ -53,15 +61,12 @@ def main():
             idx_path = int(fname[:-5].split("_")[1])
             path = os.path.join(args.folder, fname)
             post_text, titre = load_post(path, args.stem)
-            posts.append({
-                "title" : titre,
-                "fname" : fname,
-                "content" : post_text,
-                "idx" : idx_path
-            })
+            posts.append(
+                {"title": titre, "fname": fname, "content": post_text, "idx": idx_path}
+            )
 
-    #Clustering, puis affichage
-    clusters = cluster_posts(posts, stem=args.stem, eps=1-args.sim)
+    # Clustering, puis affichage
+    clusters = cluster_posts(posts, stem=args.stem, eps=1 - args.sim)
     end = time.time()
     i = 1
     for label, posts in clusters.items():
@@ -72,7 +77,6 @@ def main():
                 print(f"- Mensonge {post['idx']} \t|  {post['title']}")
             i += 1
     print(f"Temps de calcul : {(end-start):.4f}")
-
 
 
 if __name__ == "__main__":

--- a/download_posts.py
+++ b/download_posts.py
@@ -1,7 +1,8 @@
-from bs4 import BeautifulSoup
 import requests
 import json
 import os
+
+from bs4 import BeautifulSoup
 
 # On commence par supprimer tout ce qu'il y a dans data/
 for fname in os.listdir("data"):
@@ -12,11 +13,10 @@ for i in range(200):  # Augmenter ce nombre s'il y a plus de mensonge sur le sit
     url = f"https://vigiedumensonge.fr/e/{i}"
 
     response = requests.get(url)
-    if response.status_code !=200:
+    if response.status_code != 200:
         print(f"Mensonge {i} : status {response.status_code}")
         continue
     response.raise_for_status()  # Lève une erreur si le téléchargement échoue
-
 
     soup = BeautifulSoup(response.text, "html.parser")
 
@@ -32,18 +32,20 @@ for i in range(200):  # Augmenter ce nombre s'il y a plus de mensonge sur le sit
     faits = faits_title.find_next("p").get_text("\n", strip=True) if faits_title else ""
 
     # Date d'ajout
-    date_elem = soup.find("p", string=lambda text: text and text.startswith("Ajouté le"))
+    date_elem = soup.find(
+        "p", string=lambda text: text and text.startswith("Ajouté le")
+    )
     date_ajout = date_elem.get_text(strip=True) if date_elem else ""
     donnees = {
-        'titre': titre,
-        'date_ajout': date_ajout,
-        'citation': citation,
-        'faits': faits
+        "titre": titre,
+        "date_ajout": date_ajout,
+        "citation": citation,
+        "faits": faits,
     }
     print(f" - {i} : {titre}")
 
     # Sauvegarde JSON
-    with open(f'data/mensonge_{i}.json', 'w', encoding='utf-8') as f:
+    with open(f"data/mensonge_{i}.json", "w", encoding="utf-8") as f:
         json.dump(donnees, f, ensure_ascii=False, indent=4)
     if 0:
         # Affichage

--- a/similar_post.py
+++ b/similar_post.py
@@ -1,12 +1,13 @@
 import os
 import argparse
-from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.metrics.pairwise import cosine_similarity
-#import spacy
 import re
 import time
 from utils import preprocess, load_post
 
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+# import spacy
 
 
 def find_similar_posts(posts, index, top_n=5):
@@ -27,9 +28,17 @@ def find_similar_posts(posts, index, top_n=5):
 def main():
     parser = argparse.ArgumentParser(description="Trouver les posts similaires")
     parser.add_argument("index", type=int, help="Index du post de référence (ex: 1)")
-    parser.add_argument("--folder", type=str, default="data", help="Dossier contenant les fichiers JSON")
-    parser.add_argument("--top", type=int, default=5, help="Nombre de posts similaires à afficher")
-    parser.add_argument("--stem", action="store_true", help="Activer le stemming avec FrenchStemmer de nltk")
+    parser.add_argument(
+        "--folder", type=str, default="data", help="Dossier contenant les fichiers JSON"
+    )
+    parser.add_argument(
+        "--top", type=int, default=5, help="Nombre de posts similaires à afficher"
+    )
+    parser.add_argument(
+        "--stem",
+        action="store_true",
+        help="Activer le stemming avec FrenchStemmer de nltk",
+    )
 
     args = parser.parse_args()
     folder = args.folder
@@ -60,11 +69,11 @@ def main():
     results = find_similar_posts(posts, index, top)
     end = time.time()
 
-    print(f"Post de référence : \n # {filenames[index]}\t| \"{titles[index]}\"")
+    print(f'Post de référence : \n # {filenames[index]}\t| "{titles[index]}"')
     print()
     print("Posts similaires :")
     for i, score in results:
-        print(f" - {filenames[i]}\t| similarité={score:.4f}    | \"{titles[i]}\"")
+        print(f' - {filenames[i]}\t| similarité={score:.4f}    | "{titles[i]}"')
     print()
     print(f"Temps d'exécution : {(end-start):.4f}")
 

--- a/utils.py
+++ b/utils.py
@@ -1,41 +1,47 @@
-from nltk.tokenize import word_tokenize
-from nltk.stem.snowball import FrenchStemmer
 import json
-import nltk
 import unicodedata
-from nltk.corpus import stopwords
 import string
 
-#nltk.download('punkt_tab')
-#nltk.download('stopwords')
+from nltk.stem.snowball import FrenchStemmer
+from nltk.tokenize import word_tokenize
+import nltk
+from nltk.corpus import stopwords
+
+# nltk.download('punkt_tab')
+# nltk.download('stopwords')
 
 
 def preprocess(text, stem=False):
-    text = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("utf-8")  # Supprimer tout les accents pour réduire l'impact des fautes sur les accents
-    tokens = word_tokenize(text, language='french')  # Tokenization
+    text = (
+        unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("utf-8")
+    )  # Supprimer tout les accents pour réduire l'impact des fautes sur les accents
+    tokens = word_tokenize(text, language="french")  # Tokenization
     tokens = [token.lower() for token in tokens]  # Passer tout en minuscule
 
     # Suppressions des stops words, et des token composé uniquement de punctuation
-    stop_words = set(stopwords.words('french'))
+    stop_words = set(stopwords.words("french"))
     stop_words.add("mensonge")
     stop_words.add("edit")
     stop_words.add("doublon")
-    tokens = [t for t in tokens if t not in stop_words and not all(c in string.punctuation for c in t)]
+    tokens = [
+        t
+        for t in tokens
+        if t not in stop_words and not all(c in string.punctuation for c in t)
+    ]
 
     if stem:
         stemmer = FrenchStemmer()
         tokens = [stemmer.stem(t) for t in tokens]
 
-    return ' '.join(tokens)
+    return " ".join(tokens)
+
 
 def load_post(path, stem):
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
         # Utiliser "text" ou autre champ pertinent
-        post_text = ' '.join([
-            data.get('titre', ''),
-            data.get('citation', ''),
-            data.get('faits', '')
-        ])
+        post_text = " ".join(
+            [data.get("titre", ""), data.get("citation", ""), data.get("faits", "")]
+        )
         post_text = preprocess(post_text, stem)
         return post_text, data.get("titre")


### PR DESCRIPTION
Je chipote, c'est juste histoire que le code respecte [PEP8](https://peps.python.org/pep-0008/), notamment:

- La longueur maximum pour une ligne
- La façon dont les opérateurs doivent être espacés (ex: A != B plutôt que A!=B)
- L'ordre dans lequel les modules doivent être importés (ceux de la bibliothèque standard d'abord)